### PR TITLE
modular log/abort, then support PAT of github

### DIFF
--- a/lib/github-common.sh
+++ b/lib/github-common.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+## Log <type> <msg>
+log () {
+  printf "  \033[36m%10s\033[0m : \033[90m%s\033[0m\n" $1 $2
+}
+
+## abort
+abort () {
+  printf "\n  \033[31mError: $@\033[0m\n\n" && exit 1
+}
+
 ## export
 if [[ ${BASH_SOURCE[0]} != $0 ]]; then
 
@@ -10,5 +20,7 @@ if [[ ${BASH_SOURCE[0]} != $0 ]]; then
   export GH_TOKEN="${GH_TOKEN:-$(
     test -f ${GH_TOKEN_PATH} && cat ${GH_TOKEN_PATH} | head -n1
   )}"
+  export log
+  export abort
 
 fi

--- a/lib/github.sh
+++ b/lib/github.sh
@@ -25,7 +25,7 @@ github () {
 
     ## flags
     -V|--version)
-      echo "${VERSION}"
+      log version "${VERSION}"
       return 0
       ;;
 


### PR DESCRIPTION
I improved the UX like n, and support the PAT(Personal Access Token) authentication for bash-github, IMO PAT is better than OAUTH2 in bash, right?

The ScreenShot of the new UI is following:
1. The Type Selection Page:
   ![screen shot 2014-06-10 at 6 18 27 pm](https://cloud.githubusercontent.com/assets/1935767/3228643/16135946-f089-11e3-9fbc-a3a0cecf2802.png)
2. Landing Page of PAT:
   ![screen shot 2014-06-10 at 6 18 33 pm](https://cloud.githubusercontent.com/assets/1935767/3228647/19b59fb4-f089-11e3-9f26-a7b819759f08.png)
